### PR TITLE
Switch add and remove buttons to be more logical as UI

### DIFF
--- a/class-gf-field-repeater-end.php
+++ b/class-gf-field-repeater-end.php
@@ -104,8 +104,8 @@ class GF_Field_Repeater_End extends GF_Field {
 			$field_content = "<div class=\"ginput_container ginput_container_repeater-end\">\n";
 
 			if (!$hideButtons) {
-				$field_content .= "<span class=\"gf_repeater_add\" {$tabindex}>{$add_html}</span>";
 				$field_content .= "<span class=\"gf_repeater_remove\" {$tabindex}>{$remove_html}</span>";
+				$field_content .= "<span class=\"gf_repeater_add\" {$tabindex}>{$add_html}</span>";
 			}
 
 			$field_content .= "</div>";


### PR DESCRIPTION
Because it removes the previous repeated field. This way it's more intuitive for the uses.

This example says:

[ Remove the above / previous added person - ]
[ Add a new person + ]

![screen shot 2016-03-20 at 20 57 23](https://cloud.githubusercontent.com/assets/145887/13906742/664e832c-eede-11e5-92e5-0ad8337cb8f2.png)
