### PR TITLE
GF_REPEATER_DEBUG Filter

### DIFF
--- a/repeater.php
+++ b/repeater.php
@@ -12,7 +12,7 @@ GitHub Branch: development
 
 define('GF_REPEATER_VERSION', '1.1.0-dev14');
 define('GF_REPEATER_PATH', basename(__DIR__).'/'.basename(__FILE__));
-define('GF_REPEATER_DEBUG', WP_DEBUG);
+define('GF_REPEATER_DEBUG', apply_filters( 'gf_repeater_debug_filter', WP_DEBUG ) );
 
 add_filter('plugin_row_meta', 'gfrepeater_row_meta', 10, 2);
 function gfrepeater_row_meta($links, $file) {


### PR DESCRIPTION
Some sites need to use the development branch in production while also using `WP_DEBUG` to log and track errors. ie `WP_DEBUG_DISPLAY = false`

Adding a filter keeps backwards compat in place but allows the value to be overridden if necessary.
