### PR TITLE
Enabling debug is not the same as tracing values aka var_dump-ing

### DIFF
--- a/repeater.php
+++ b/repeater.php
@@ -12,7 +12,9 @@ GitHub Branch: development
 
 define('GF_REPEATER_VERSION', '1.1.0-dev14');
 define('GF_REPEATER_PATH', basename(__DIR__).'/'.basename(__FILE__));
-define('GF_REPEATER_DEBUG', WP_DEBUG);
+if( !defined('GF_REPEATER_DEBUG') ){
+	define('GF_REPEATER_DEBUG', WP_DEBUG);
+}
 
 add_filter('plugin_row_meta', 'gfrepeater_row_meta', 10, 2);
 function gfrepeater_row_meta($links, $file) {


### PR DESCRIPTION
I want debug info like notices and warnings, but I don't want any var_dump in my e-mails
