### PR TITLE
fix pre-population issue over multiple rows

### DIFF
--- a/class-gf-field-repeater.php
+++ b/class-gf-field-repeater.php
@@ -317,7 +317,7 @@ class GF_Field_Repeater extends GF_Field {
 
 					if (!empty($repeater_parems)) {
 						if (array_key_exists($repeater_child, $repeater_parems)) {
-							$repeater_children_info[$repeater_child]['prePopulate'] = $repeater_parems[$repeater_child];
+							$repeater_children_info[$repeater_child]['prePopulate'] = $repeater_parems;
 						}
 					}
 


### PR DESCRIPTION
Fix #100

Removes `$repeater_child` because JS expect to have the field id provided